### PR TITLE
Active users queries 

### DIFF
--- a/googleanalytics/columns.py
+++ b/googleanalytics/columns.py
@@ -23,6 +23,12 @@ DIMENSIONS = {
     'ga:dateHour': lambda date: utils.date.parse('{} {}'.format(date[:8], date[8:])),
 }
 
+PYSLUG_OVERRIDES = {
+    '1dayUsers': 'active_1day_users',
+    '7dayUsers': 'active_7day_users',
+    '14dayUsers': 'active_14day_users',
+    '30dayUsers': 'active_30day_users',
+}
 
 def escape_chars(value, chars=',;'):
     if value is True:
@@ -42,6 +48,13 @@ def escape(method):
         values = utils.builtins.map(escape_chars, values)
         return method(self, *values)
     return escaped_method
+
+
+def pyslug(name):
+    """
+    Make name safe to use as an attribute name (Python identifier).
+    """
+    return PYSLUG_OVERRIDES.get(name) or re.sub(r'([A-Z])', r'_\1', name).lower()
 
 
 class Column(object):
@@ -85,7 +98,7 @@ class Column(object):
             self.index = int(index.group(0))
         else:
             self.index = None
-        self.pyslug = re.sub(r'([A-Z])', r'_\1', self.slug).lower()
+        self.pyslug = pyslug(self.slug)
         self.attributes = attributes
         self.name = attributes.get('uiName', column_id).replace('XX', str(self.index))
         self.group = attributes.get('group')
@@ -191,7 +204,7 @@ class Segment(Column):
         self.raw = raw
         self.id = raw['segmentId']
         self.report_type, self.slug = self.id.split('::')
-        self.pyslug = re.sub(r'([A-Z])', r'_\1', self.slug).lower()
+        self.pyslug = pyslug(self.slug)
         self.name = raw['name']
         self.kind = raw['kind'].lower()
         self.definition = raw['definition']


### PR DESCRIPTION
Names for active users metrics start with a digit (e.g. '1dayUsers'),
so are not valid python identifiers.
This throws an exeception when a namedtuple is created for the report.
So when generating the 'pyslug', start digits should be escaped.
Added an mapping to override these names, since I prefer a human readable name for the result column (instead of a generic prefix in the regexp to escape all future starting digits).
